### PR TITLE
Add option for align repos's description

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,6 +47,17 @@ The default cache location is ~$HOME/.emacs.d/hgs-cache~, you can customize this
 (setq helm-github-stars-cache-file "/cache/path")
 #+END_SRC
 
+*** Align repositories's description
+For a clean look, you can align repositories's description by customize
+~helm-github-stars-name-length~, for example:
+#+BEGIN_SRC elisp
+(setq helm-github-stars-name-length 30)
+#+END_SRC
+
+Its defualt vaule is ~nil~ becuase when you have two or more repositories with
+very similar name and description, you may open the wrong URL. Though, in
+practice, that rarely happens.
+
 ** Run tests
 Move into repository's root directory and run:
 #+BEGIN_SRC shell

--- a/helm-github-stars.el
+++ b/helm-github-stars.el
@@ -87,7 +87,7 @@ When disabled (nil) don't align description."
                           "\n"))))
     :action '(("Browse URL" .
                (lambda (candidate)
-                 (let ((repo-name (if (null helm-github-stars-cache-file)
+                 (let ((repo-name (if (null helm-github-stars-name-length)
                                       (substring candidate 0 (string-match " - " candidate))
                                     (hgs/get-repo-name candidate (hgs/get-github-stars)))))
                    (browse-url (concat hgs/github-url repo-name)))))))
@@ -105,7 +105,7 @@ When disabled (nil) don't align description."
                           "\n"))))
     :action '(("Browse URL" .
                (lambda (candidate)
-                 (let ((repo-name (if (null helm-github-stars-cache-file)
+                 (let ((repo-name (if (null helm-github-stars-name-length)
                                       (substring candidate 0 (string-match " - " candidate))
                                     (hgs/get-repo-name candidate (hgs/get-github-repos)))))
                    (browse-url (concat hgs/github-url repo-name)))))))

--- a/helm-github-stars.el
+++ b/helm-github-stars.el
@@ -66,7 +66,7 @@
   "Cache file for starred repositories."
   :type 'file)
 
-(defcustom helm-github-stars-name-length 30
+(defcustom helm-github-stars-name-length nil
   "Length of repo name before truncate.
 When disabled (nil) don't align description."
   :type  '(choice (const :tag "Disabled" nil)

--- a/helm-github-stars.el
+++ b/helm-github-stars.el
@@ -118,7 +118,7 @@ When disabled (nil) don't align description."
 
 (defun hgs/align-description (item)
   "Truncate repo name in ITEM."
-  (let* ((index (string-match" - " item))
+  (let* ((index (string-match " - " item))
          (name (substring item 0 index))
          (description (substring item (+ 3 index))))
     (concat

--- a/test/helm-github-stars-test.el
+++ b/test/helm-github-stars-test.el
@@ -114,4 +114,27 @@
    (f-write-text hgs-test/cache-string 'utf-8 cache-test-file)
    (should (not (helm-github-stars-fetch)))))
 
+(ert-deftest hgs/align-description-test ()
+  (let ((helm-github-stars-name-length 7)
+        (repo1 "repo/a - description")
+        (repo2 "repo/bb - description")
+        (repo3 "repo/ccc - description")
+        (repo4 "repo/dddd - description"))
+    (should (string-equal (hgs/align-description repo1) "repo/a       description"))
+    (should (string-equal (hgs/align-description repo2) "repo/bb      description"))
+    (should (string-equal (hgs/align-description repo3) "repo/cc...   description"))
+    (should (string-equal (hgs/align-description repo4) "repo/dd...   description"))))
+
+(ert-deftest hgs/get-repo-name-test ()
+  (let* ((helm-github-stars-name-length 7)
+         (repo1 "repo/a - description")
+         (repo2 "repo/bb - description")
+         (repo3 "repo/ccc - description")
+         (repo4 "repo/dddd - description")
+         (repos (vector repo1 repo2 repo3 repo4)))
+    (should (string-equal "repo/a"    (hgs/get-repo-name (hgs/align-description repo1) repos)))
+    (should (string-equal "repo/bb"   (hgs/get-repo-name (hgs/align-description repo2) repos)))
+    (should (string-equal "repo/ccc"  (hgs/get-repo-name (hgs/align-description repo3) repos)))
+    (should (string-equal "repo/dddd" (hgs/get-repo-name (hgs/align-description repo4) repos)))))
+
 ;;; helm-github-stars-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -40,6 +40,7 @@
   "Test file for cache tests.")
 
 (require 'f)
+(require 'helm-utils)                   ; for `helm-substring-by-width' function
 (require 'helm-github-stars
          (expand-file-name "helm-github-stars.el" root-dir))
 


### PR DESCRIPTION
The option is `helm-github-stars-name-length', its default value
is 30.

There is a tiny change that user opens a wrong URL when both
description and (substring name 0 helm-github-stars-name-length)
is not unique. e.g.,

username/repo-foo - This is a sample repo
username/repo-bar - This is a sample repo

when helm-github-stars-name-length is 10, Helm show the following:

username/repo...   This is a sample repo
username/repo...   This is a sample repo

in this case the result might get wrong.

Fixes #8
