### PR TITLE
Support private repositories

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,7 +49,7 @@ The default cache location is ~$HOME/.emacs.d/hgs-cache~, you can customize this
 #+END_SRC
 
 *** Align repositories's description
-For a clean look, you can align repositories's description by customize
+For a clean look, you can align repositories's description by customizing
 ~helm-github-stars-name-length~, for example:
 #+BEGIN_SRC elisp
 (setq helm-github-stars-name-length 30)
@@ -58,6 +58,10 @@ For a clean look, you can align repositories's description by customize
 Its default value is ~nil~ because when you have two or more repositories with
 very similar name and description, you may open the wrong URL. Though, in
 practice, that rarely happens.
+
+*** Private repositories
+If you want to be able to show your private repositories, customize
+~helm-github-stars-token~ then call ~helm-github-stars-fetch~ or ~helm-github-stars~.
 
 ** Run tests
 Move into repository's root directory and run:

--- a/helm-github-stars.el
+++ b/helm-github-stars.el
@@ -52,6 +52,7 @@
 (require 'helm)
 (require 'json)
 (require 'subr-x)
+(eval-when-compile (require 'cl))
 
 (defgroup helm-github-stars nil
   "Helm integration for your starred repositories on github."

--- a/helm-github-stars.el
+++ b/helm-github-stars.el
@@ -208,46 +208,34 @@ METHOD is a funcall symbol, call it for a list of stars and repos."
   (let ((stars-list [])
         (repos-list [])
         (cache-hash-table (make-hash-table :test 'equal)))
-    (if helm-github-stars-token
-        (progn
-          ;; Fetch user's starred repositories
-          (mapc (lambda (item)
-                  (setq stars-list
-                        (vconcat stars-list
-                                 (vector (concat
-                                          (cdr (assoc 'full_name item))
-                                          " - "
-                                          (cdr (assoc 'description item)))))))
-                (hgs/request-github-stars-by-token))
-          ;; Fetch user's repositories (inlucding private repos, if possible)
-          (mapc (lambda (item)
-                  (setq repos-list
-                        (vconcat repos-list
-                                 (vector (concat
-                                          (cdr (assoc 'full_name item))
-                                          " - "
-                                          (cdr (assoc 'description item)))))))
-                (hgs/request-github-repos-by-token)))
-      ;; Fetch user's starred repositories
-      (let ((next-request t)
-            (current-page 1))
-        (while next-request
-          (let ((response (hgs/parse-github-response (hgs/request-github-stars current-page))))
-            (if (= 0 (length response))
-                (setq next-request nil)
-              (progn
-                (setq stars-list (vconcat stars-list response))
-                (setq current-page (1+ current-page)))))))
-      ;; Fetch user's repositories
-      (let ((next-request t)
-            (current-page 1))
-        (while next-request
-          (let ((response (hgs/parse-github-response (hgs/request-github-repos current-page))))
-            (if (= 0 (length response))
-                (setq next-request nil)
-              (progn
-                (setq repos-list (vconcat repos-list response))
-                (setq current-page (1+ current-page))))))))
+    ;; Fetch user's starred repositories
+    (let ((next-request t)
+          (current-page 1))
+      (while next-request
+        (let ((response (hgs/parse-github-response
+                         (funcall (if helm-github-stars-token
+                                      'hgs/request-github-stars-by-token
+                                    'hgs/request-github-stars)
+                                  current-page))))
+          (if (= 0 (length response))
+              (setq next-request nil)
+            (progn
+              (setq stars-list (vconcat stars-list response))
+              (setq current-page (1+ current-page)))))))
+    ;; Fetch user's repositories
+    (let ((next-request t)
+          (current-page 1))
+      (while next-request
+        (let ((response (hgs/parse-github-response
+                         (funcall (if helm-github-stars-token
+                                      'hgs/request-github-repos-by-token
+                                    'hgs/request-github-repos)
+                                  current-page))))
+          (if (= 0 (length response))
+              (setq next-request nil)
+            (progn
+              (setq repos-list (vconcat repos-list response))
+              (setq current-page (1+ current-page)))))))
 
     (puthash '"stars" stars-list cache-hash-table)
     (puthash '"repos" repos-list cache-hash-table)
@@ -267,19 +255,21 @@ METHOD is a funcall symbol, call it for a list of stars and repos."
                               "/repos?per_page=100&page="
                               (number-to-string page))))
 
-(defun hgs/request-github-repos-by-token ()
-  "Request Github API user's repositories and return JSON response."
+(defun hgs/request-github-repos-by-token (page)
+  "Request Github API user's repositories and return response."
   (let ((url-request-extra-headers `(("Authorization" .
                                       ,(format "token %s" helm-github-stars-token)))))
-    (json-read-from-string
-     (hgs/request-github "https://api.github.com/user/repos"))))
+    (hgs/request-github (concat
+                         "https://api.github.com/user/repos?per_page=100&page="
+                         (number-to-string page)))))
 
-(defun hgs/request-github-stars-by-token ()
-  "Request Github API user's repositories and return JSON response."
+(defun hgs/request-github-stars-by-token (page)
+  "Request Github API user's repositories and return response."
   (let ((url-request-extra-headers `(("Authorization" .
                                       ,(format "token %s" helm-github-stars-token)))))
-    (json-read-from-string
-     (hgs/request-github "https://api.github.com/user/starred"))))
+    (hgs/request-github (concat
+                         "https://api.github.com/user/starred?per_page=100&page="
+                         (number-to-string page)))))
 
 (defun hgs/request-github (url)
   "Request Github URL and return response."

--- a/helm-github-stars.el
+++ b/helm-github-stars.el
@@ -99,58 +99,48 @@ When disabled (nil) don't align description."
 (defvar hgs/github-url "https://github.com/"
   "Github URL for browsing.")
 
+(defun helm-github-stars-source-init (method)
+  "Helm source initialization.
+
+METHOD is a funcall symbol, call it for a list of stars, repos or private repos."
+  (lexical-let ((method method))
+    (lambda ()
+      (with-current-buffer (helm-candidate-buffer 'local)
+        (insert
+         (mapconcat (if (null helm-github-stars-name-length)
+                        'identity
+                      #'hgs/align-description)
+                    (funcall method)
+                    "\n"))))))
+
+(defun helm-github-stars-source-action (method)
+  "Helm source action.
+
+METHOD is a funcall symbol, call it for a list of stars, repos or private repos."
+  `(("Browse URL" .
+     ,(lexical-let ((method method))
+        (lambda (candidate)
+          (let ((repo-name (if (null helm-github-stars-name-length)
+                               (substring candidate 0 (string-match " - " candidate))
+                             (hgs/get-repo-name candidate (funcall method)))))
+            (browse-url (concat hgs/github-url repo-name))))))))
+
 (defvar hgs/helm-c-source-stars
   (helm-build-in-buffer-source "Starred repositories"
-    :init (lambda ()
-            (with-current-buffer (helm-candidate-buffer 'local)
-              (insert
-               (mapconcat (if (null helm-github-stars-name-length)
-                              'identity
-                            #'hgs/align-description)
-                          (hgs/get-github-stars)
-                          "\n"))))
-    :action '(("Browse URL" .
-               (lambda (candidate)
-                 (let ((repo-name (if (null helm-github-stars-name-length)
-                                      (substring candidate 0 (string-match " - " candidate))
-                                    (hgs/get-repo-name candidate (hgs/get-github-stars)))))
-                   (browse-url (concat hgs/github-url repo-name)))))))
+    :init (helm-github-stars-source-init 'hgs/get-github-stars)
+    :action (helm-github-stars-source-action 'hgs/get-github-stars))
   "Helm source definition.")
 
 (defvar hgs/helm-c-source-repos
   (helm-build-in-buffer-source "Your repositories"
-    :init (lambda ()
-            (with-current-buffer (helm-candidate-buffer 'local)
-              (insert
-               (mapconcat (if (null helm-github-stars-name-length)
-                              'identity
-                            #'hgs/align-description)
-                          (hgs/get-github-repos)
-                          "\n"))))
-    :action '(("Browse URL" .
-               (lambda (candidate)
-                 (let ((repo-name (if (null helm-github-stars-name-length)
-                                      (substring candidate 0 (string-match " - " candidate))
-                                    (hgs/get-repo-name candidate (hgs/get-github-repos)))))
-                   (browse-url (concat hgs/github-url repo-name)))))))
+    :init (helm-github-stars-source-init 'hgs/get-github-repos)
+    :action (helm-github-stars-source-action 'hgs/get-github-repos))
   "Helm source definition.")
 
 (defvar hgs/helm-c-source-private-repos
   (helm-build-in-buffer-source "Your private repositories"
-    :init (lambda ()
-            (with-current-buffer (helm-candidate-buffer 'local)
-              (insert
-               (mapconcat (if (null helm-github-stars-name-length)
-                              'identity
-                            #'hgs/align-description)
-                          (hgs/get-github-private-repos)
-                          "\n"))))
-    :action '(("Browse URL" .
-               (lambda (candidate)
-                 (let ((repo-name (if (null helm-github-stars-name-length)
-                                      (substring candidate 0 (string-match " - " candidate))
-                                    (hgs/get-repo-name candidate (hgs/get-github-private-repos)))))
-                   (browse-url (concat hgs/github-url repo-name)))))))
+    :init (helm-github-stars-source-init 'hgs/get-github-private-repos)
+    :action (helm-github-stars-source-action 'hgs/get-github-private-repos))
   "Helm source definition.")
 
 (defvar hgs/helm-c-source-search


### PR DESCRIPTION
Github Application token is needed to enable this feature,

also see docstring of `helm-github-stars-token' for more info.
